### PR TITLE
Add get.override-with-inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `get.override-with-inputs`
+
 ### Changed
 
 ### Deprecated


### PR DESCRIPTION
 Allows easy overrides of a dictionary (typically a toml config) with values passed from command line
(eg. `--input deep.key=value`).